### PR TITLE
feat: 헤더 로고 추가

### DIFF
--- a/frontend/src/assets/logo.svg
+++ b/frontend/src/assets/logo.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                        <defs>
+                            <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                                <stop offset="0%" style="stop-color:#3B82F6; stop-opacity:1" /> <!-- blue-500 -->
+                                <stop offset="100%" style="stop-color:#6366F1; stop-opacity:1" /> <!-- indigo-500 -->
+                            </linearGradient>
+                        </defs>
+                        <!-- 국회의사당 돔 + 말풍선 -->
+                        <path d="M50 5 C25 5, 5 25, 5 50 C5 70, 20 90, 45 95 L45 75 C30 70, 20 60, 20 50 C20 30, 35 15, 50 15 C65 15, 80 30, 80 50 C80 60, 70 70, 55 75 L55 95 C80 90, 95 70, 95 50 C95 25, 75 5, 50 5 Z" fill="url(#logoGradient)"/>
+                        <!-- 투표 체크 표시 -->
+                        <path d="M40 50 L50 60 L65 45" stroke="white" stroke-width="6" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "react-router-dom";
 import { ROUTES } from "@/routes/path";
+import LogoIcon from "@/assets/logo.svg";
 
 export const Header = () => {
   const location = useLocation();
@@ -13,7 +14,9 @@ export const Header = () => {
       <div className="container mx-auto px-4 py-4">
         <div className="flex items-center justify-between">
           <Link to={ROUTES.HOME} className="flex items-center">
-            <h1 className="text-2xl font-bold text-blue-700">국회잇슈</h1>
+          <img src={LogoIcon} alt="로고" className="w-10 h-10 mr-2" /> 
+            <h1 className="text-2xl font-bold">국회</h1>
+            <h1 className="text-2xl font-bold text-blue-700">잇슈</h1>
           </Link>
 
           <nav className="flex items-center space-x-8">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 헤더 브랜딩을 텍스트 로고에서 아이콘과 분리된 타이틀(“국회” / “잇슈”) 구성으로 변경했습니다. “잇슈”의 파란색 강조를 유지해 브랜드 아이덴티티를 강화하고, 다양한 해상도에서 시인성과 일관성을 높였습니다. 레이아웃, HOME 링크 및 내비게이션 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->