### PR TITLE
fix: 회의 논의사항 합치지 말고 리스트로 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/donzo/naitssu/domain/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/com/donzo/naitssu/domain/meeting/dto/MeetingResponse.java
@@ -2,6 +2,8 @@ package com.donzo.naitssu.domain.meeting.dto;
 
 import com.donzo.naitssu.domain.meeting.entity.Meeting;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,75 +13,67 @@ import java.util.List;
 @Getter
 @Builder
 public class MeetingResponse {
-    
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
     private Long id;
-    
+
     @JsonProperty("confer_num")
     private String conferNum; // 회의번호
-    
+
     private String title; // 회의명
-    
+
     @JsonProperty("class_name")
     private String className; // 회의종류명
-    
+
     @JsonProperty("dae_num")
     private String daeNum; // 대수
-    
+
     @JsonProperty("conf_date")
     private String confDate; // 회의날짜
-    
+
     @JsonProperty("sub_name")
     private String subName; // 안건명
-    
+
     @JsonProperty("vod_link_url")
     private String vodLinkUrl; // 영상회의록 링크
-    
+
     @JsonProperty("conf_link_url")
     private String confLinkUrl; // 요약정보 팝업
-    
+
     @JsonProperty("pdf_link_url")
     private String pdfLinkUrl; // PDF파일 링크
-    
+
     @JsonProperty("conf_id")
     private String confId; // 회의ID
-    
+
     private String summary; // PDF 요약 내용
-    
+
     @JsonProperty("discussion_items")
     private List<String> discussionItems; // 주요 논의사항
-    
+
     @JsonProperty("created_at")
     private LocalDateTime createdAt; // 생성일시
-    
+
     @JsonProperty("updated_at")
     private LocalDateTime updatedAt; // 수정일시
-    
+
     public static MeetingResponse from(Meeting meeting) {
-        List<String> discussionItems = null;
+        List<String> discussionItems = List.of();
+
         if (meeting.getDiscussionItems() != null && !meeting.getDiscussionItems().trim().isEmpty()) {
             try {
-                // JSON 문자열을 List로 변환 (간단한 파싱)
-                String json = meeting.getDiscussionItems().trim();
-                if (json.startsWith("[") && json.endsWith("]")) {
-                    json = json.substring(1, json.length() - 1);
-                    if (!json.trim().isEmpty()) {
-                        discussionItems = List.of(json.split("\",\""))
-                                .stream()
-                                .map(item -> item.replace("\"", "").trim())
-                                .filter(item -> !item.isEmpty())
-                                .toList();
-                    }
-                }
+                // ObjectMapper를 사용하여 JSON 문자열을 List로 변환
+                discussionItems = objectMapper.readValue(
+                        meeting.getDiscussionItems(),
+                        new TypeReference<>() {}
+                );
             } catch (Exception e) {
                 // 파싱 실패 시 빈 리스트
                 discussionItems = List.of();
             }
         }
-        
-        if (discussionItems == null) {
-            discussionItems = List.of();
-        }
-        
+
         return MeetingResponse.builder()
                 .id(meeting.getId())
                 .conferNum(meeting.getConferNum())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 없음
* 버그 수정
  * 회의 상세 화면에서 토론 항목이 간헐적으로 표시되지 않거나 로딩이 실패하던 문제를 수정했습니다.
* 개선
  * 토론 항목 데이터 처리 안정성을 높여 잘못된 형식의 데이터가 있어도 앱이 중단되지 않도록 했습니다.
  * 토론 항목이 없는 경우에도 빈 목록으로 일관되게 표시되어 화면 경험이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->