### PR TITLE
feat : 법률안 목록 태그 필터링

### DIFF
--- a/frontend/src/apis/hooks/useBills.ts
+++ b/frontend/src/apis/hooks/useBills.ts
@@ -6,6 +6,7 @@ export const useBills = (params?: BillPageParams) => {
   return useQuery<BillPageResponse>({
     queryKey: ["bills", params],
     queryFn: () => billsService.getBillsPage(params),
+    enabled: params !== undefined,
     staleTime: 1000 * 60 * 5, // 5분
   });
 };
@@ -14,6 +15,7 @@ export const useBillsByVotes = (params?: BillPageParams) => {
   return useQuery<BillPageResponse>({
     queryKey: ["billsByVotes", params],
     queryFn: () => billsService.getBillsPageByVotes(params),
+    enabled: params !== undefined,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/frontend/src/apis/types/bills.ts
+++ b/frontend/src/apis/types/bills.ts
@@ -31,4 +31,5 @@ export interface BillPageParams {
   page?: number;
   size?: number;
   sort?: string;
+  tag?: string;
 }

--- a/frontend/src/components/MeetingChatbot.tsx
+++ b/frontend/src/components/MeetingChatbot.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { MessageCircleMore } from "lucide-react";
 
 interface MeetingChatbotProps {

--- a/frontend/src/pages/BillPage/components/TagButtons.tsx
+++ b/frontend/src/pages/BillPage/components/TagButtons.tsx
@@ -1,0 +1,47 @@
+export type TagType =
+  | "all"
+  | "transport"
+  | "housing"
+  | "economy"
+  | "environment"
+  | "employment"
+  | "other";
+
+interface TagButtonsProps {
+  onTagChange: (tag: TagType) => void;
+  currentTag: TagType;
+}
+
+const TAGS: { key: TagType; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "transport", label: "교통" },
+  { key: "housing", label: "주거" },
+  { key: "economy", label: "경제" },
+  { key: "environment", label: "환경" },
+  { key: "employment", label: "고용" },
+  { key: "other", label: "기타" },
+];
+
+export const TagButtons = ({ onTagChange, currentTag }: TagButtonsProps) => {
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {TAGS.map(({ key, label }) => (
+        <button
+          key={key}
+          onClick={() => onTagChange(key)}
+          className={`px-4 py-2 text-sm font-medium rounded-full transition-all cursor-pointer ${
+            currentTag === key
+              ? "bg-blue-500 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default TagButtons;
+
+

--- a/frontend/src/pages/BillPage/index.tsx
+++ b/frontend/src/pages/BillPage/index.tsx
@@ -75,15 +75,19 @@ export const BillPage = () => {
 
   const handleSearch = (query: string) => {
     setSearchQuery(query);
+    setSortType("latest");
+    setCurrentTag("all");
     setCurrentPage(0);
   };
 
   const handleSortChange = (newSortType: SortType) => {
+    setSearchQuery("");
     setSortType(newSortType);
     setCurrentPage(0);
   };
 
   const handleTagChange = (newTag: TagType) => {
+    setSearchQuery("");
     setCurrentTag(newTag);
     setCurrentPage(0);
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 법안 페이지에 태그 필터 추가(예: 전체, 경제, 사회, 문화 등)로 목록을 세분화해 탐색 가능.
  - 태그와 정렬(최신/인기) 조합을 지원하여 원하는 기준으로 목록을 볼 수 있음.
  - 상단에 태그 버튼 UI 추가, 선택 상태가 시각적으로 표시되며 변경 시 페이지가 초기화됨.

- Refactor
  - 검색·정렬·태그 상태에 따라 데이터 소스를 자동 선택하고 로딩/에러 처리를 정비해 응답성과 안정성 개선.

- Chores
  - API 타입에 선택적 tag 파라미터 추가 및 데이터 조회의 자동 실행 조건 보완.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->