### PR TITLE
feat: 렌더링 배수 수정

### DIFF
--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -155,8 +155,8 @@ function TopBillsSection({ topBills, isLoading, isError }: { topBills: any[] | u
   // 첫 번째 카드는 HOT 섹션에서 사용하므로 나머지 3개만 사용
   const remainingBills = topBills ? topBills.slice(1, 4) : [];
 
-  // 무한 루프를 위해 동일한 배열을 두 번 이어 붙임
-  const marqueeItems = [...remainingBills, ...remainingBills];
+  // 무한 루프를 위해 동일한 배열을 세 번 이어 붙임
+  const marqueeItems = [...remainingBills, ...remainingBills, ...remainingBills];
 
   return (
     <>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 홈 화면의 무한 마키(롤링 배너) 순환 길이를 확장해 더 많은 항목이 연속적으로 노출됩니다.
  - 스크롤 반복 주기가 길어져 동일 항목의 재등장 간격이 늘어나 시각적 반복감이 줄고 읽기 흐름이 부드러워졌습니다.
  - 긴 목록에서도 끊김 없는 흐름을 강화하여, 상단 주요 콘텐츠 확인 후에도 롤링 영역에서 다양한 항목을 더 오래 살펴볼 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->